### PR TITLE
Expose springboot actuator endpoints through camel route - 3533

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 1.1.1
+
+        * [CP-3533] - Expose springboot actuator endpoints through camel route
+
 ## Version 1.1.0
 
         * [CP-3303] - Return paybill validation response message

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'org.mifos'
 sourceCompatibility = '17'
-version = '1.1.0'
+version = '1.1.1'
 
 def camelCoreVersion = '3.19.0'
 

--- a/src/main/java/org/mifos/connector/airtel/camel/routes/ActuatorRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/airtel/camel/routes/ActuatorRouteBuilder.java
@@ -1,0 +1,23 @@
+package org.mifos.connector.airtel.camel.routes;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Route builder for exposing spring boot actuator endpoints.
+ */
+@Component
+public class ActuatorRouteBuilder extends RouteBuilder {
+
+    @Value("${server.port:8080}")
+    private String port;
+
+    @Override
+    public void configure() throws Exception {
+        from("rest:GET:/actuator?matchOnUriPrefix=true")
+            .setHeader(Exchange.HTTP_PATH, simple("${header.CamelHttpPath}"))
+            .toD("http://localhost:" + port + "/actuator${header.CamelHttpPath}?bridgeEndpoint=true&throwExceptionOnFailure=false");
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exposed Spring Boot actuator endpoints through a new route, allowing access via a dedicated HTTP path.

- **Chores**
  - Updated release notes to version 1.1.1.
  - Incremented project version to 1.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->